### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/app/travel-ui/assets/scripts/d3.js
+++ b/app/travel-ui/assets/scripts/d3.js
@@ -81,11 +81,20 @@ function makechart(data) {
     document.querySelector("div.graphbox").appendChild(chart);
 }
 
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 function drawchart(city) {
     document.querySelector("div.graphbox").innerHTML = "";
     
     const err = function(error) {
-        document.querySelector("div.graphbox").innerHTML = "no data for city: " + city;
+        document.querySelector("div.graphbox").innerHTML = "no data for city: " + escapeHtml(city);
     }
     d3.json("/data/" + city).then(makechart).catch(err);
 }


### PR DESCRIPTION
Fixes [https://github.com/tullo/travel/security/code-scanning/1](https://github.com/tullo/travel/security/code-scanning/1)

To fix the problem, we need to ensure that any user input used in HTML content is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a function that escapes HTML special characters before inserting the user input into the DOM.

1. Create a function to escape HTML special characters.
2. Use this function to escape the `city` variable before concatenating it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
